### PR TITLE
Add passkey login guidance

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,7 @@ Welcome to the codebase for the GRH Rental Services, a Next.js application used 
 - Multiple views for booking, dashboards, help pages and more
 - Realtime chat and push notifications
 - Passwordless email authentication
+- Optional passkey sign-in after verifying your email and registering a passkey
 - Admin and rental dashboards
 - Multi-language support (English & German)
 - Responsive UI built with Tailwind and shadcn/ui
@@ -96,6 +97,7 @@ npm run start
 ## 6. Important Concepts
 
 - **Authentication** – Passwordless email sign-in using one-time codes. The configuration lives in `auth.ts` and uses NextAuth with Prisma as an adapter.
+- You can also sign in with a passkey once your email is verified and a passkey is registered to your account.
 - **TRPC API** – Typed API routes defined under `src/server/routers`. The client uses hooks in `src/utils/trpc.ts` to call them.
 - **Views & Components** – The main page switches between list view, booking forms and dashboards using a view context (`src/contexts/ViewContext.tsx`). UI pieces live in `src/components`.
 - **Localization** – JSON translation files in `src/locales` with language preference stored in `localStorage`.

--- a/src/contexts/AuthModalContext.tsx
+++ b/src/contexts/AuthModalContext.tsx
@@ -386,6 +386,9 @@ export const AuthModalProvider = ({ children }: { children: ReactNode }) => {
                         </>
                       )}
                     </Button>
+                    <p className="text-xs text-muted-foreground text-center">
+                      {t("auth.passkeyLoginInfo")}
+                    </p>
 
                     <div className="relative">
                       <div className="absolute inset-0 flex items-center">

--- a/src/locales/de.json
+++ b/src/locales/de.json
@@ -233,7 +233,8 @@
     "signInSuccessDescription": "Du bist jetzt angemeldet.",
     "orContinueWith": "oder fortfahren mit",
     "signInWithPasskey": "Mit Passkey anmelden",
-    "authenticating": "Authentifiziere..."
+    "authenticating": "Authentifiziere...",
+    "passkeyLoginInfo": "Passkey-Anmeldung ist erst nach Bestätigung deiner E-Mail und Hinzufügen eines Passkeys möglich"
   },
   "profile": {
     "setNameTitle": "Willkommen! Wie hei\u00dft du?",

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -233,7 +233,8 @@
     "signInSuccessDescription": "You are now signed in.",
     "orContinueWith": "or continue with",
     "signInWithPasskey": "Sign in with Passkey",
-    "authenticating": "Authenticating..."
+    "authenticating": "Authenticating...",
+    "passkeyLoginInfo": "Passkey sign-in is available after verifying your email and adding a passkey"
   },
   "profile": {
     "setNameTitle": "Welcome! What's your name?",


### PR DESCRIPTION
## Summary
- mention passkey sign-in in feature list and auth section
- show note that passkeys require verified email in auth modal
- add translations for passkey login info in EN/DE locales

## Testing
- `npm test` *(fails: vitest not found)*
- `npm run lint` *(fails: couldn't download dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_685dbcc61e1c8330a75102cb0b153b9c