### PR TITLE
Promote passkey setup in the header

### DIFF
--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -26,6 +26,7 @@ import {
   UserCog,
   UserCircle,
   HelpCircle,
+  Fingerprint,
 } from "lucide-react"
 import NotificationBell from "@/components/NotificationBell"
 import {
@@ -51,7 +52,7 @@ export default function Header() {
   const router = useRouter()
   const pathname = usePathname()
   const { view, setView } = useView()
-  const { openPrompt } = useNamePrompt()
+  const { openPrompt, openPasskeyPrompt } = useNamePrompt()
   const { openAuthModal } = useAuthModal()
 
   const [isMenuOpen, setIsMenuOpen] = useState(false)
@@ -263,6 +264,18 @@ export default function Header() {
               </Button>
             )}
 
+            {status === "authenticated" && (
+              <Button
+                variant="secondary"
+                size="sm"
+                onClick={() => openPasskeyPrompt()}
+                className="font-semibold"
+              >
+                <Fingerprint className="mr-1.5 h-4 w-4" />
+                {t("header.addPasskeyCta")}
+              </Button>
+            )}
+
             <Button
               variant="ghost"
               size="icon"
@@ -453,6 +466,19 @@ export default function Header() {
               >
                 <UserCircle className="mr-2 h-4 w-4" />
                 {t(isProfileIncomplete ? "header.completeProfileCta" : "header.editProfileLink")}
+              </Button>
+            )}
+            {status === "authenticated" && (
+              <Button
+                variant="secondary"
+                className="justify-start"
+                onClick={() => {
+                  setIsMenuOpen(false)
+                  openPasskeyPrompt()
+                }}
+              >
+                <Fingerprint className="mr-2 h-4 w-4" />
+                {t("header.addPasskeyCta")}
               </Button>
             )}
             {isRentalTeam && (

--- a/src/contexts/NamePromptContext.tsx
+++ b/src/contexts/NamePromptContext.tsx
@@ -3,7 +3,7 @@
 import { createContext, useContext, useState, useEffect, ReactNode } from "react"
 import { useSession } from "next-auth/react"
 import NamePrompt from "@/components/NamePrompt"
-import type { NamePromptContextType } from "@/types/view"
+import type { NamePromptContextType, NamePromptTarget } from "@/types/view"
 
 const NamePromptContext = createContext<NamePromptContextType | undefined>(undefined)
 
@@ -16,6 +16,7 @@ export function NamePromptProvider({ children }: { children: ReactNode }) {
   const { data: session, status } = useSession()
   const [open, setOpen] = useState(false)
   const [isManuallyOpened, setIsManuallyOpened] = useState(false)
+  const [initialSection, setInitialSection] = useState<NamePromptTarget | undefined>()
 
   useEffect(() => {
     if (status !== "authenticated") {
@@ -38,21 +39,26 @@ export function NamePromptProvider({ children }: { children: ReactNode }) {
   /**
    * Manually open the name prompt dialog
    */
-  const openPrompt = () => {
+  const openPrompt = (targetSection?: NamePromptTarget) => {
     setIsManuallyOpened(true)
+    setInitialSection(targetSection)
     setOpen(true)
   }
+  const openPasskeyPrompt = () => openPrompt("passkeys")
   const handleOpenChange = (newOpen: boolean) => {
     setOpen(newOpen)
     if (!newOpen) {
       setIsManuallyOpened(false)
+      setInitialSection(undefined)
     }
   }
 
   return (
-    <NamePromptContext.Provider value={{ openPrompt }}>
+    <NamePromptContext.Provider value={{ openPrompt, openPasskeyPrompt }}>
       {children}
-      {status === "authenticated" && <NamePrompt open={open} onOpenChange={handleOpenChange} />}
+      {status === "authenticated" && (
+        <NamePrompt open={open} onOpenChange={handleOpenChange} initialSection={initialSection} />
+      )}
     </NamePromptContext.Provider>
   )
 }

--- a/src/locales/de.json
+++ b/src/locales/de.json
@@ -195,6 +195,7 @@
     "toggleMenu": "Menü umschalten",
     "editProfileLink": "Profileinstellungen",
     "completeProfileCta": "Profil vervollständigen",
+    "addPasskeyCta": "Passkey hinzufügen",
     "signedInAs": "Angemeldet als {email}",
     "helpButton": "Schnellhilfe",
     "helpDialogTitle": "Brauchst du Hilfe beim Start?",

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -196,6 +196,7 @@
     "editProfileLink": "Profile Settings",
     "signedInAs": "Signed in as {email}",
     "completeProfileCta": "Complete Profile",
+    "addPasskeyCta": "Add a passkey",
     "helpButton": "Quick help",
     "helpDialogTitle": "Need help getting started?",
     "helpDialogIntro": "Here’s how sign-in and bookings work.",

--- a/src/types/view.ts
+++ b/src/types/view.ts
@@ -29,6 +29,9 @@ export interface ViewContextType {
 }
 
 // Name prompt context
+export type NamePromptTarget = "profile" | "passkeys"
+
 export interface NamePromptContextType {
-  openPrompt: () => void
+  openPrompt: (targetSection?: NamePromptTarget) => void
+  openPasskeyPrompt: () => void
 }


### PR DESCRIPTION
## Summary
- add prominent desktop and mobile header actions to open passkey setup
- allow the profile/security dialog to focus the passkey section with scrolling and button focus
- update translations and context wiring to support targeting the passkey registration area

## Testing
- npm run lint

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692c8117278c8330b799636622b17aac)