### PR TITLE
test: add tests for adminBlock utilities

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11220,9 +11220,6 @@
       "version": "5.0.0-beta.30",
       "resolved": "https://registry.npmjs.org/next-auth/-/next-auth-5.0.0-beta.30.tgz",
       "integrity": "sha512-+c51gquM3F6nMVmoAusRJ7RIoY0K4Ts9HCCwyy/BRoe4mp3msZpOzYMyb5LAYc1wSo74PMQkGDcaghIO7W6Xjg==",
-      "version": "5.0.0-beta.30",
-      "resolved": "https://registry.npmjs.org/next-auth/-/next-auth-5.0.0-beta.30.tgz",
-      "integrity": "sha512-+c51gquM3F6nMVmoAusRJ7RIoY0K4Ts9HCCwyy/BRoe4mp3msZpOzYMyb5LAYc1wSo74PMQkGDcaghIO7W6Xjg==",
       "license": "ISC",
       "dependencies": {
         "@auth/core": "0.41.0"

--- a/src/utils/__tests__/adminBlock.test.ts
+++ b/src/utils/__tests__/adminBlock.test.ts
@@ -1,0 +1,46 @@
+import { describe, it, expect } from "vitest"
+import { isAdminBlockBooking, getAdminBlockReason } from "../adminBlock"
+import { ADMIN_BLOCK_PREFIX } from "@/constants/booking"
+
+describe("adminBlock utilities", () => {
+  describe("isAdminBlockBooking", () => {
+    it("returns false if booking has no notes", () => {
+      expect(isAdminBlockBooking({})).toBe(false)
+      expect(isAdminBlockBooking({ notes: null })).toBe(false)
+      expect(isAdminBlockBooking({ notes: undefined })).toBe(false)
+      expect(isAdminBlockBooking({ notes: "" })).toBe(false)
+    })
+
+    it("returns false if notes do not start with ADMIN_BLOCK_PREFIX", () => {
+      expect(isAdminBlockBooking({ notes: "Some other note" })).toBe(false)
+      expect(isAdminBlockBooking({ notes: " " + ADMIN_BLOCK_PREFIX })).toBe(false)
+    })
+
+    it("returns true if notes start with ADMIN_BLOCK_PREFIX", () => {
+      expect(isAdminBlockBooking({ notes: ADMIN_BLOCK_PREFIX })).toBe(true)
+      expect(isAdminBlockBooking({ notes: `${ADMIN_BLOCK_PREFIX} reason` })).toBe(true)
+    })
+  })
+
+  describe("getAdminBlockReason", () => {
+    it("returns null if notes are empty or null", () => {
+      expect(getAdminBlockReason(null)).toBe(null)
+      expect(getAdminBlockReason(undefined)).toBe(null)
+      expect(getAdminBlockReason("")).toBe(null)
+    })
+
+    it("returns null if notes do not start with ADMIN_BLOCK_PREFIX", () => {
+      expect(getAdminBlockReason("Some note")).toBe(null)
+    })
+
+    it("returns null if notes contain only the prefix (trimmed result is empty)", () => {
+      expect(getAdminBlockReason(ADMIN_BLOCK_PREFIX)).toBe(null)
+      expect(getAdminBlockReason(`${ADMIN_BLOCK_PREFIX} `)).toBe(null)
+    })
+
+    it("returns the trimmed reason when notes start with the prefix and have content", () => {
+      expect(getAdminBlockReason(`${ADMIN_BLOCK_PREFIX} Maintenance`)).toBe("Maintenance")
+      expect(getAdminBlockReason(`${ADMIN_BLOCK_PREFIX}   Cleanup  `)).toBe("Cleanup")
+    })
+  })
+})


### PR DESCRIPTION
Added unit tests for `isAdminBlockBooking` and `getAdminBlockReason` in `src/utils/adminBlock.ts` to improve test coverage.

Verified with `vitest`.
Confirmed no regressions (existing failures in booking routers are pre-existing).

---
*PR created automatically by Jules for task [3424911084390630198](https://jules.google.com/task/3424911084390630198) started by @cakirmert*