### PR TITLE
⚡ Optimize deleteInactiveUsers with batch operations

### DIFF
--- a/src/server/jobs/__tests__/deleteInactiveUsers.test.ts
+++ b/src/server/jobs/__tests__/deleteInactiveUsers.test.ts
@@ -5,7 +5,7 @@ vi.mock("node-cron", () => ({ default: { schedule: vi.fn() } }))
 const prisma = {
   user: {
     findMany: vi.fn().mockResolvedValue([{ id: "u1" }]),
-    delete: vi.fn().mockResolvedValue({}),
+    deleteMany: vi.fn().mockResolvedValue({}),
   },
   booking: {
     deleteMany: vi.fn().mockResolvedValue({}),
@@ -19,7 +19,7 @@ describe("deleteInactiveUsers", () => {
     const { deleteInactiveUsers } = await import("../deleteInactiveUsers")
     await deleteInactiveUsers()
     expect(prisma.user.findMany).toHaveBeenCalled()
-    expect(prisma.booking.deleteMany).toHaveBeenCalledWith({ where: { userId: "u1" } })
-    expect(prisma.user.delete).toHaveBeenCalledWith({ where: { id: "u1" } })
+    expect(prisma.booking.deleteMany).toHaveBeenCalledWith({ where: { userId: { in: ["u1"] } } })
+    expect(prisma.user.deleteMany).toHaveBeenCalledWith({ where: { id: { in: ["u1"] } } })
   })
 })

--- a/src/server/jobs/__tests__/deleteInactiveUsers_perf.test.ts
+++ b/src/server/jobs/__tests__/deleteInactiveUsers_perf.test.ts
@@ -1,0 +1,32 @@
+import { describe, it, expect, vi } from "vitest"
+
+vi.mock("node-cron", () => ({ default: { schedule: vi.fn() } }))
+
+// Mock return 10 users
+const users = Array.from({ length: 10 }, (_, i) => ({ id: `u${i}` }))
+
+const prisma = {
+  user: {
+    findMany: vi.fn().mockResolvedValue(users),
+    deleteMany: vi.fn().mockResolvedValue({}),
+  },
+  booking: {
+    deleteMany: vi.fn().mockResolvedValue({}),
+  },
+}
+
+vi.mock("@/lib/prismadb", () => ({ __esModule: true, default: prisma }))
+
+describe("deleteInactiveUsers Performance", () => {
+  it("should execute optimized queries (no N+1)", async () => {
+    const { deleteInactiveUsers } = await import("../deleteInactiveUsers")
+    await deleteInactiveUsers()
+
+    // We expect user.findMany to be called once
+    expect(prisma.user.findMany).toHaveBeenCalledTimes(1)
+
+    // Optimized behavior: 1 call each regardless of user count
+    expect(prisma.booking.deleteMany).toHaveBeenCalledTimes(1)
+    expect(prisma.user.deleteMany).toHaveBeenCalledTimes(1)
+  })
+})

--- a/src/server/jobs/deleteInactiveUsers.ts
+++ b/src/server/jobs/deleteInactiveUsers.ts
@@ -9,8 +9,17 @@ export async function deleteInactiveUsers() {
     select: { id: true },
   })
 
-  for (const { id } of users) {
-    await prisma.booking.deleteMany({ where: { userId: id } })
-    await prisma.user.delete({ where: { id } })
+  const userIds = users.map((u) => u.id)
+
+  if (userIds.length === 0) {
+    return
   }
+
+  await prisma.booking.deleteMany({
+    where: { userId: { in: userIds } },
+  })
+
+  await prisma.user.deleteMany({
+    where: { id: { in: userIds } },
+  })
 }


### PR DESCRIPTION
💡 **What:**
Optimized the `deleteInactiveUsers` background job by replacing a loop of individual delete operations with batch `deleteMany` queries.

🎯 **Why:**
The previous implementation suffered from an N+1 query problem. For `N` inactive users, it executed `2N + 1` database queries (1 fetch, N booking deletes, N user deletes). This could lead to performance degradation and database timeouts as the number of inactive users grows.

📊 **Measured Improvement:**
- **Baseline:** `2N + 1` queries.
- **Optimized:** `3` queries (1 fetch, 1 batch booking delete, 1 batch user delete).
- **Test:** Added `src/server/jobs/__tests__/deleteInactiveUsers_perf.test.ts` which verifies that `deleteMany` is called exactly once for bookings and once for users, regardless of the number of users returned.


---
*PR created automatically by Jules for task [5782290553587794416](https://jules.google.com/task/5782290553587794416) started by @cakirmert*