### PR TITLE
🔒 Fix missing authorization in item image upload

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11220,9 +11220,6 @@
       "version": "5.0.0-beta.30",
       "resolved": "https://registry.npmjs.org/next-auth/-/next-auth-5.0.0-beta.30.tgz",
       "integrity": "sha512-+c51gquM3F6nMVmoAusRJ7RIoY0K4Ts9HCCwyy/BRoe4mp3msZpOzYMyb5LAYc1wSo74PMQkGDcaghIO7W6Xjg==",
-      "version": "5.0.0-beta.30",
-      "resolved": "https://registry.npmjs.org/next-auth/-/next-auth-5.0.0-beta.30.tgz",
-      "integrity": "sha512-+c51gquM3F6nMVmoAusRJ7RIoY0K4Ts9HCCwyy/BRoe4mp3msZpOzYMyb5LAYc1wSo74PMQkGDcaghIO7W6Xjg==",
       "license": "ISC",
       "dependencies": {
         "@auth/core": "0.41.0"

--- a/src/server/routers/__tests__/admin.upload.test.ts
+++ b/src/server/routers/__tests__/admin.upload.test.ts
@@ -1,0 +1,58 @@
+
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { uploadRouter } from "../adminRouter";
+import type { Context } from "@/server/context";
+
+// Mock @vercel/blob
+vi.mock("@vercel/blob", () => ({
+  put: vi.fn().mockResolvedValue({ url: "https://example.com/image.jpg" }),
+}));
+
+function createCaller(role: "ADMIN" | "USER" = "USER") {
+  const prisma = {};
+  const ctx: Context = {
+    prisma: prisma as any,
+    session: {
+      user: { id: "user1", role: role, email: "user@example.com", name: "User" },
+      expires: "2024-12-31T23:59:59.000Z",
+    },
+  } as any;
+
+  const caller = uploadRouter.createCaller(ctx);
+  return { caller };
+}
+
+describe("uploadItemImage security check", () => {
+  const originalEnv = process.env;
+
+  beforeEach(() => {
+    vi.resetModules();
+    process.env = { ...originalEnv, BLOB_READ_WRITE_TOKEN: "mock-token" };
+  });
+
+  afterEach(() => {
+    process.env = originalEnv;
+  });
+
+  it("denies non-admin access to upload image", async () => {
+    const { caller } = createCaller("USER");
+
+    await expect(
+      caller.uploadItemImage({
+        fileName: "test.jpg",
+        fileContentBase64: "base64content",
+      })
+    ).rejects.toThrow("FORBIDDEN");
+  });
+
+  it("allows admin to upload image", async () => {
+    const { caller } = createCaller("ADMIN");
+
+    const result = await caller.uploadItemImage({
+      fileName: "test.jpg",
+      fileContentBase64: "base64content",
+    });
+
+    expect(result).toEqual({ imageUrl: "https://example.com/image.jpg" });
+  });
+});

--- a/src/server/routers/adminRouter.ts
+++ b/src/server/routers/adminRouter.ts
@@ -399,7 +399,8 @@ export const uploadRouter = router({
         fileContentBase64: z.string(),
       }),
     )
-    .mutation(async ({ input }) => {
+    .mutation(async ({ ctx, input }) => {
+      ensureAdmin(ctx)
       try {
         const fileExtension = path.extname(input.fileName)
         const uniqueFileName = `items/${uuidv4()}${fileExtension}`


### PR DESCRIPTION
This PR fixes a security vulnerability in the `uploadItemImage` endpoint.

**Vulnerability:**
The `uploadItemImage` mutation was protected by authentication (`protectedProcedure`) but lacked a role check, allowing any logged-in user to upload images.

**Fix:**
- Added `ensureAdmin(ctx)` to the `uploadItemImage` mutation handler.
- Updated the mutation signature to include `ctx`.

**Verification:**
- Added `src/server/routers/__tests__/admin.upload.test.ts` to verify the fix.
- Ran existing tests to ensure no regressions (unrelated failures in other tests were noted).

---
*PR created automatically by Jules for task [3008204969094647497](https://jules.google.com/task/3008204969094647497) started by @cakirmert*