### PR TITLE
Fix empty catch block in ChatDialog and RentalDashboardView

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11220,9 +11220,6 @@
       "version": "5.0.0-beta.30",
       "resolved": "https://registry.npmjs.org/next-auth/-/next-auth-5.0.0-beta.30.tgz",
       "integrity": "sha512-+c51gquM3F6nMVmoAusRJ7RIoY0K4Ts9HCCwyy/BRoe4mp3msZpOzYMyb5LAYc1wSo74PMQkGDcaghIO7W6Xjg==",
-      "version": "5.0.0-beta.30",
-      "resolved": "https://registry.npmjs.org/next-auth/-/next-auth-5.0.0-beta.30.tgz",
-      "integrity": "sha512-+c51gquM3F6nMVmoAusRJ7RIoY0K4Ts9HCCwyy/BRoe4mp3msZpOzYMyb5LAYc1wSo74PMQkGDcaghIO7W6Xjg==",
       "license": "ISC",
       "dependencies": {
         "@auth/core": "0.41.0"

--- a/src/components/ChatDialog.tsx
+++ b/src/components/ChatDialog.tsx
@@ -104,7 +104,15 @@ export default function ChatDialog({ open, onOpenChange, bookingId, itemTitle }:
     const io = new IntersectionObserver(
       ([entry]) => {
         if (entry.isIntersecting && msgsQry.hasNextPage) {
-          msgsQry.fetchNextPage().catch(() => {})
+          msgsQry.fetchNextPage().catch((error) => {
+            console.error("Failed to fetch next page:", error)
+            toast({
+              title: t("common.error"),
+              description:
+                error instanceof Error ? error.message : "Failed to load older messages",
+              variant: "destructive",
+            })
+          })
         }
       },
       { root: pane },
@@ -112,7 +120,7 @@ export default function ChatDialog({ open, onOpenChange, bookingId, itemTitle }:
 
     io.observe(sentinel)
     return () => io.disconnect()
-  }, [msgsQry])
+  }, [msgsQry, t])
 
   // ─────── Guard UI after hooks ───────
   if (!bookingId) return null

--- a/src/components/RentalDashboardView.tsx
+++ b/src/components/RentalDashboardView.tsx
@@ -716,7 +716,17 @@ export default function RentalDashboardView({ onGoBack }: RentalDashboardViewPro
       {viewMode === "list" && hasNextPage && (
         <div className="mt-6 text-center print:hidden">
           <Button
-            onClick={() => fetchNextPage()}
+            onClick={() =>
+              fetchNextPage().catch((error) => {
+                console.error("Failed to fetch next page:", error)
+                toast({
+                  title: t("common.error"),
+                  description:
+                    error instanceof Error ? error.message : "Failed to load more bookings",
+                  variant: "destructive",
+                })
+              })
+            }
             disabled={isFetchingNextPage || isLoading}
             variant="outline"
             size="sm"


### PR DESCRIPTION
Addressed code health issue by replacing empty catch block with proper error handling in `ChatDialog.tsx`. Also applied similar fix to `RentalDashboardView.tsx`. This ensures errors during infinite scroll fetch are logged and communicated to the user via toast.


---
*PR created automatically by Jules for task [10785804439100126384](https://jules.google.com/task/10785804439100126384) started by @cakirmert*