### PR TITLE
🔒 Fix unbounded input for booking notes

### DIFF
--- a/src/server/routers/__tests__/bookings.notes.test.ts
+++ b/src/server/routers/__tests__/bookings.notes.test.ts
@@ -1,0 +1,78 @@
+import { describe, it, expect, vi } from "vitest"
+import type { Context } from "@/server/context"
+
+// Mock Prisma
+const prisma = {
+  booking: {
+    findUnique: vi.fn(),
+    create: vi.fn().mockResolvedValue({ id: "new-booking", status: "REQUESTED" }),
+    update: vi.fn().mockResolvedValue({ id: "booking1" }),
+    aggregate: vi.fn().mockResolvedValue({ _sum: { quantity: 0 } }),
+  },
+  item: {
+    findUnique: vi.fn().mockResolvedValue({
+      id: "item1",
+      totalQuantity: 10,
+      responsibleMembers: [],
+    }),
+  },
+  log: { create: vi.fn() },
+}
+
+vi.mock("@/lib/prismadb", () => ({ __esModule: true, default: prisma }))
+vi.mock("@/server/notifications/bookingStatusNotifier", () => ({ notifyBookingStatusChange: vi.fn() }))
+vi.mock("@/server/email/sendBookingRequestEmail", () => ({ sendBookingRequestEmail: vi.fn() }))
+
+async function createCaller() {
+  const { bookingsRouter } = await import("../bookings")
+  const ctx: Context = {
+    prisma: prisma as unknown as Context["prisma"],
+    session: {
+      user: { id: "user1", role: "USER", email: "test@example.com", name: "Test User" },
+      expires: new Date(Date.now() + 24 * 60 * 60 * 1000).toISOString(),
+    },
+    req: new Request("http://localhost"),
+  }
+  return bookingsRouter.createCaller(ctx)
+}
+
+describe("booking notes validation", () => {
+  const longNote = "a".repeat(1001)
+
+  it("should fail creating a booking with too long notes", async () => {
+    const caller = await createCaller()
+    // Use future dates to avoid "past date" error
+    const futureStart = new Date(Date.now() + 1000 * 60 * 60 * 24 * 2) // 2 days in future
+    const futureEnd = new Date(futureStart.getTime() + 1000 * 60 * 60 * 24) // 1 day duration
+
+    const input = {
+      itemId: "item1",
+      start: futureStart.toISOString(),
+      end: futureEnd.toISOString(),
+      notes: longNote,
+      quantity: 1,
+    }
+
+    // This should reject if validation is working
+    await expect(caller.create(input)).rejects.toThrow()
+  })
+
+  it("should fail updating a booking with too long notes", async () => {
+    const caller = await createCaller()
+    prisma.booking.findUnique.mockResolvedValue({ userId: "user1", status: "REQUESTED" })
+
+    // Use future dates to avoid "past date" error
+    const futureStart = new Date(Date.now() + 1000 * 60 * 60 * 24 * 2) // 2 days in future
+    const futureEnd = new Date(futureStart.getTime() + 1000 * 60 * 60 * 24) // 1 day duration
+
+    const input = {
+      id: "booking1",
+      start: futureStart.toISOString(),
+      end: futureEnd.toISOString(),
+      notes: longNote,
+    }
+
+    // This should reject if validation is working
+    await expect(caller.update(input)).rejects.toThrow()
+  })
+})

--- a/src/server/routers/bookings.ts
+++ b/src/server/routers/bookings.ts
@@ -69,7 +69,7 @@ export const bookingsRouter = router({
         quantity: z.number().int().min(1).default(1),
         start: z.string(), // ISO string
         end: z.string(), // ISO string
-        notes: z.string().optional(),
+        notes: z.string().max(1000).optional(),
       }),
     )
     .mutation(async ({ input, ctx }) => {
@@ -195,7 +195,7 @@ export const bookingsRouter = router({
         id: z.string(),
         start: z.string(), // ISO string
         end: z.string(), // ISO string
-        notes: z.string().optional(),
+        notes: z.string().max(1000).optional(),
       }),
     )
     .mutation(async ({ input, ctx }) => {
@@ -394,7 +394,7 @@ export const bookingsRouter = router({
     .input(
       z.object({
         bookingId: z.string(),
-        note: z.string(),
+        note: z.string().max(1000),
       }),
     )
     .mutation(async ({ input, ctx }) => {


### PR DESCRIPTION
* 🎯 **What:** The vulnerability fixed: Unbounded string input for `notes` field in `create` and `update` mutations and `note` in `addRentalNote` mutation.
* ⚠️ **Risk:** Potential Denial of Service (DoS) or database issues if excessively large strings are submitted.
* 🛡️ **Solution:** Added `.max(1000)` constraint to the Zod schema for these fields.
* ✅ **Verification:** Added `src/server/routers/__tests__/bookings.notes.test.ts` to reproduce the issue (long notes rejected) and verified it passes. Ran existing tests to ensure no regressions (confirmed pre-existing failures are unrelated).

---
*PR created automatically by Jules for task [14922991168687635898](https://jules.google.com/task/14922991168687635898) started by @cakirmert*