### PR TITLE
⚡ Optimize deleteInactiveUsers to use batch delete operations

### DIFF
--- a/src/server/jobs/__tests__/deleteInactiveUsers.test.ts
+++ b/src/server/jobs/__tests__/deleteInactiveUsers.test.ts
@@ -5,21 +5,28 @@ vi.mock("node-cron", () => ({ default: { schedule: vi.fn() } }))
 const prisma = {
   user: {
     findMany: vi.fn().mockResolvedValue([{ id: "u1" }]),
-    delete: vi.fn().mockResolvedValue({}),
+    deleteMany: vi.fn().mockResolvedValue({ count: 1 }),
   },
   booking: {
-    deleteMany: vi.fn().mockResolvedValue({}),
+    deleteMany: vi.fn().mockResolvedValue({ count: 1 }),
   },
 }
 
 vi.mock("@/lib/prismadb", () => ({ __esModule: true, default: prisma }))
 
 describe("deleteInactiveUsers", () => {
-  it("removes bookings and user records", async () => {
+  it("removes bookings and user records using batch delete", async () => {
     const { deleteInactiveUsers } = await import("../deleteInactiveUsers")
     await deleteInactiveUsers()
+
     expect(prisma.user.findMany).toHaveBeenCalled()
-    expect(prisma.booking.deleteMany).toHaveBeenCalledWith({ where: { userId: "u1" } })
-    expect(prisma.user.delete).toHaveBeenCalledWith({ where: { id: "u1" } })
+
+    expect(prisma.booking.deleteMany).toHaveBeenCalledWith({
+      where: { userId: { in: ["u1"] } },
+    })
+
+    expect(prisma.user.deleteMany).toHaveBeenCalledWith({
+      where: { id: { in: ["u1"] } },
+    })
   })
 })

--- a/src/server/jobs/deleteInactiveUsers.ts
+++ b/src/server/jobs/deleteInactiveUsers.ts
@@ -9,8 +9,18 @@ export async function deleteInactiveUsers() {
     select: { id: true },
   })
 
-  for (const { id } of users) {
-    await prisma.booking.deleteMany({ where: { userId: id } })
-    await prisma.user.delete({ where: { id } })
+  const userIds = users.map((u) => u.id)
+
+  if (userIds.length > 0) {
+    await prisma.booking.deleteMany({
+      where: {
+        userId: { in: userIds },
+      },
+    })
+    await prisma.user.deleteMany({
+      where: {
+        id: { in: userIds },
+      },
+    })
   }
 }


### PR DESCRIPTION
💡 **What:** Optimized `deleteInactiveUsers` job by replacing a loop of individual `delete` calls with batch `deleteMany` operations.
🎯 **Why:** To resolve an N+1 query issue that caused performance degradation when deleting multiple inactive users.
📊 **Measured Improvement:**
  - **Before:** executed `2N + 1` queries (where N is the number of inactive users).
  - **After:** executes constant `3` queries regardless of N (1 select + 1 delete bookings + 1 delete users).
  - Note: Live benchmark was not possible due to environment restrictions (missing database connection), but the theoretical improvement is significant for large N. Unit tests were updated to verify the correct use of `deleteMany` with `IN` operator.


---
*PR created automatically by Jules for task [5782376098109641557](https://jules.google.com/task/5782376098109641557) started by @cakirmert*