### PR TITLE
Add tests for adminBlock utils and fix booking router tests

### DIFF
--- a/src/server/routers/__tests__/bookings.cancel.log.test.ts
+++ b/src/server/routers/__tests__/bookings.cancel.log.test.ts
@@ -10,6 +10,7 @@ const prisma = {
       .mockResolvedValue({ userId: "u1", status: BookingStatus.REQUESTED, startDate: new Date() }),
     update: vi.fn().mockResolvedValue({ id: "b1" }),
   },
+  notification: { create: vi.fn() },
   log: { create: vi.fn() },
 }
 
@@ -17,12 +18,19 @@ vi.mock("@/lib/prismadb", () => ({ __esModule: true, default: prisma }))
 
 async function createCaller() {
   const { bookingsRouter } = await import("../bookings")
-  prisma.booking.findUnique.mockResolvedValue({
+  const mockBooking = {
+    id: "b1",
     userId: "u1",
     status: BookingStatus.REQUESTED,
     startDate: new Date(),
-  })
-  prisma.booking.update.mockResolvedValue({ id: "b1" })
+    endDate: new Date(),
+    item: { titleEn: "Item" },
+    user: { id: "u1", email: "test@example.com", name: "Test User" },
+    assignedTo: null,
+    notes: null,
+  }
+  prisma.booking.findUnique.mockResolvedValue(mockBooking)
+  prisma.booking.update.mockResolvedValue({ ...mockBooking, status: BookingStatus.CANCELLED })
   const ctx: Context = {
     prisma: prisma as unknown as Context["prisma"],
     session: {

--- a/src/server/routers/__tests__/bookings.cancel.test.ts
+++ b/src/server/routers/__tests__/bookings.cancel.test.ts
@@ -8,6 +8,7 @@ const prisma = {
     findUnique: vi.fn().mockResolvedValue({ userId: "user1", status: BookingStatus.REQUESTED }),
     update: vi.fn(),
   },
+  notification: { create: vi.fn() },
   log: { create: vi.fn() },
 }
 
@@ -15,8 +16,19 @@ vi.mock("@/lib/prismadb", () => ({ __esModule: true, default: prisma }))
 
 async function createCaller(status: BookingStatus) {
   const { bookingsRouter } = await import("../bookings")
-  prisma.booking.findUnique.mockResolvedValue({ userId: "user1", status })
-  prisma.booking.update.mockResolvedValue({ id: "1" })
+  const mockBooking = {
+    id: "1",
+    userId: "user1",
+    status,
+    item: { titleEn: "Test Item" },
+    user: { id: "user1", email: "test@example.com", name: "Test User" },
+    assignedTo: null,
+    startDate: new Date(),
+    endDate: new Date(),
+    notes: null,
+  }
+  prisma.booking.findUnique.mockResolvedValue(mockBooking)
+  prisma.booking.update.mockResolvedValue({ ...mockBooking, status: BookingStatus.CANCELLED })
   const ctx: Context = {
     prisma: prisma as unknown as Context["prisma"],
     session: {

--- a/src/server/routers/__tests__/bookings.log.test.ts
+++ b/src/server/routers/__tests__/bookings.log.test.ts
@@ -22,9 +22,13 @@ async function createCaller() {
     assignedToId: null,
     notes: null,
     item: { titleEn: "Item" },
+    user: { id: "u1", email: "test@example.com", name: "Test User" },
+    assignedTo: null,
+    startDate: new Date(),
+    endDate: new Date(),
   }
   prisma.booking.findUnique.mockResolvedValue(booking)
-  prisma.booking.update.mockResolvedValue(booking)
+  prisma.booking.update.mockResolvedValue({ ...booking, status: BookingStatus.ACCEPTED })
   const ctx: Context = {
     prisma: prisma as unknown as Context["prisma"],
     session: {

--- a/src/utils/__tests__/adminBlock.test.ts
+++ b/src/utils/__tests__/adminBlock.test.ts
@@ -1,0 +1,64 @@
+import { describe, it, expect } from 'vitest'
+import { isAdminBlockBooking, getAdminBlockReason } from '../adminBlock'
+import { ADMIN_BLOCK_PREFIX } from '@/constants/booking'
+
+describe('adminBlock', () => {
+  describe('isAdminBlockBooking', () => {
+    it('returns true when notes start with ADMIN_BLOCK_PREFIX', () => {
+      const notes = `${ADMIN_BLOCK_PREFIX} Some reason`
+      expect(isAdminBlockBooking({ notes })).toBe(true)
+    })
+
+    it('returns true when notes are exactly ADMIN_BLOCK_PREFIX', () => {
+      expect(isAdminBlockBooking({ notes: ADMIN_BLOCK_PREFIX })).toBe(true)
+    })
+
+    it('returns false when notes do not start with ADMIN_BLOCK_PREFIX', () => {
+      expect(isAdminBlockBooking({ notes: 'Some other note' })).toBe(false)
+    })
+
+    it('returns false when notes are null', () => {
+      expect(isAdminBlockBooking({ notes: null })).toBe(false)
+    })
+
+    it('returns false when notes are undefined', () => {
+      expect(isAdminBlockBooking({ notes: undefined })).toBe(false)
+    })
+
+    it('returns false when notes are empty string', () => {
+      expect(isAdminBlockBooking({ notes: '' })).toBe(false)
+    })
+  })
+
+  describe('getAdminBlockReason', () => {
+    it('returns the reason when notes start with ADMIN_BLOCK_PREFIX', () => {
+      const reason = 'Maintenance work'
+      const notes = `${ADMIN_BLOCK_PREFIX} ${reason}`
+      expect(getAdminBlockReason(notes)).toBe(reason)
+    })
+
+    it('returns null when notes do not start with ADMIN_BLOCK_PREFIX', () => {
+      expect(getAdminBlockReason('Some other note')).toBe(null)
+    })
+
+    it('returns null when notes are exactly ADMIN_BLOCK_PREFIX', () => {
+      expect(getAdminBlockReason(ADMIN_BLOCK_PREFIX)).toBe(null)
+    })
+
+    it('returns null when notes are ADMIN_BLOCK_PREFIX followed by whitespace', () => {
+      expect(getAdminBlockReason(`${ADMIN_BLOCK_PREFIX}   `)).toBe(null)
+    })
+
+    it('returns null when notes are null', () => {
+      expect(getAdminBlockReason(null)).toBe(null)
+    })
+
+    it('returns null when notes are undefined', () => {
+      expect(getAdminBlockReason(undefined)).toBe(null)
+    })
+
+    it('returns null when notes are empty string', () => {
+      expect(getAdminBlockReason('')).toBe(null)
+    })
+  })
+})


### PR DESCRIPTION
This PR adds unit tests for `isAdminBlockBooking` and `getAdminBlockReason` in `src/utils/adminBlock.ts`, covering various scenarios including edge cases. 
Additionally, it fixes existing test failures in booking router tests caused by missing mock data for `item`, `user`, and `notification` relations, ensuring the full test suite passes.

---
*PR created automatically by Jules for task [6117536059251095191](https://jules.google.com/task/6117536059251095191) started by @cakirmert*