### PR TITLE
🔒 Add size validation to file upload

### DIFF
--- a/src/server/routers/__tests__/upload.test.ts
+++ b/src/server/routers/__tests__/upload.test.ts
@@ -1,0 +1,46 @@
+import { describe, it, expect, vi } from "vitest"
+import { uploadRouter } from "../adminRouter"
+import type { Context } from "@/server/context"
+
+// Mock @vercel/blob
+vi.mock("@vercel/blob", () => ({
+  put: vi.fn().mockResolvedValue({ url: "https://example.com/image.jpg" }),
+}))
+
+// Mock env
+process.env.BLOB_READ_WRITE_TOKEN = "dummy-token"
+
+function createCaller() {
+  const ctx: Context = {
+    prisma: {} as unknown as Context["prisma"], // Not used in this router
+    session: {
+      user: { id: "admin1", role: "ADMIN", email: "admin@example.com" },
+      expires: new Date(Date.now() + 24 * 60 * 60 * 1000).toISOString(),
+    },
+    req: new Request("http://localhost"),
+  }
+  return uploadRouter.createCaller(ctx)
+}
+
+describe("uploadRouter", () => {
+  it("allows upload of small file", async () => {
+    const caller = createCaller()
+    const result = await caller.uploadItemImage({
+      fileName: "test.png",
+      fileContentBase64: "SGVsbG8gV29ybGQ=", // "Hello World"
+    })
+    expect(result).toEqual({ imageUrl: "https://example.com/image.jpg" })
+  })
+
+  it("rejects upload of large file", async () => {
+    const caller = createCaller()
+    const limit = 7 * 1024 * 1024
+    const largeContent = "a".repeat(limit + 1) // > 7MB
+    await expect(
+      caller.uploadItemImage({
+        fileName: "large.png",
+        fileContentBase64: largeContent,
+      }),
+    ).rejects.toThrow()
+  })
+})

--- a/src/server/routers/admin.ts
+++ b/src/server/routers/admin.ts
@@ -344,7 +344,7 @@ export const adminRouter = router({
       orderBy: { createdAt: "desc" },
     })
 
-    const latestCancellationLogByBooking = new Map<string, typeof cancellationLogs[number]>()
+    const latestCancellationLogByBooking = new Map<string, (typeof cancellationLogs)[number]>()
     for (const log of cancellationLogs) {
       if (log.bookingId && !latestCancellationLogByBooking.has(log.bookingId)) {
         latestCancellationLogByBooking.set(log.bookingId, log)
@@ -395,7 +395,7 @@ export const uploadRouter = router({
     .input(
       z.object({
         fileName: z.string(),
-        fileContentBase64: z.string(),
+        fileContentBase64: z.string().max(7340032, "File too large"),
       }),
     )
     .mutation(async ({ input }) => {

--- a/src/server/routers/adminRouter.ts
+++ b/src/server/routers/adminRouter.ts
@@ -344,7 +344,7 @@ export const adminRouter = router({
       orderBy: { createdAt: "desc" },
     })
 
-    const latestCancellationLogByBooking = new Map<string, typeof cancellationLogs[number]>()
+    const latestCancellationLogByBooking = new Map<string, (typeof cancellationLogs)[number]>()
     for (const log of cancellationLogs) {
       if (log.bookingId && !latestCancellationLogByBooking.has(log.bookingId)) {
         latestCancellationLogByBooking.set(log.bookingId, log)
@@ -396,7 +396,7 @@ export const uploadRouter = router({
     .input(
       z.object({
         fileName: z.string(),
-        fileContentBase64: z.string(),
+        fileContentBase64: z.string().max(7340032, "File too large"),
       }),
     )
     .mutation(async ({ input }) => {


### PR DESCRIPTION
🎯 **What:** Implemented input validation for the `uploadItemImage` procedure in `adminRouter.ts` (and duplicate `admin.ts`) to limit the `fileContentBase64` string size.

⚠️ **Risk:** The previous implementation allowed unbounded file uploads, potentially leading to denial-of-service (DoS) attacks via memory exhaustion or payload size limits.

🛡️ **Solution:** Added a `.max(7340032, "File too large")` constraint to the Zod schema, limiting base64 input to approximately 7MB (roughly 5MB file size). Added unit tests to verify the fix.

---
*PR created automatically by Jules for task [1263612188678470650](https://jules.google.com/task/1263612188678470650) started by @cakirmert*