### PR TITLE
Refactor: Add logging to empty catch block in ChatDialog

### DIFF
--- a/src/components/ChatDialog.tsx
+++ b/src/components/ChatDialog.tsx
@@ -104,7 +104,9 @@ export default function ChatDialog({ open, onOpenChange, bookingId, itemTitle }:
     const io = new IntersectionObserver(
       ([entry]) => {
         if (entry.isIntersecting && msgsQry.hasNextPage) {
-          msgsQry.fetchNextPage().catch(() => {})
+          msgsQry.fetchNextPage().catch((e) => {
+            console.error("Failed to fetch next page", e)
+          })
         }
       },
       { root: pane },


### PR DESCRIPTION
This PR addresses a code health issue where an empty catch block was swallowing errors in `src/components/ChatDialog.tsx`. 

### Changes
- Replaced `.catch(() => {})` with `.catch((e) => console.error("Failed to fetch next page", e))` in the `IntersectionObserver` callback for `msgsQry.fetchNextPage()`.

### Verification
- Ran `npm run lint` - Passed.
- Ran `npm test` - All tests passed.
- Verified manual inspection of the file.

This ensures better debuggability for infinite scroll issues in the chat dialog.

---
*PR created automatically by Jules for task [1272806161670812225](https://jules.google.com/task/1272806161670812225) started by @cakirmert*