### PR TITLE
fix(security): redact sensitive OTP token in logs

### DIFF
--- a/src/app/api/auth/otp/route.test.ts
+++ b/src/app/api/auth/otp/route.test.ts
@@ -1,0 +1,68 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest"
+import { POST } from "./route"
+import { otpFailures } from "../../../../../auth"
+import prisma from "../../../../lib/prismadb"
+
+// Mock dependencies
+vi.mock("next/server", () => ({
+  NextResponse: {
+    json: vi.fn((body, init) => ({ body, init, status: init?.status || 200 })),
+  },
+}))
+
+vi.mock("../../../../../auth", () => ({
+  otpFailures: new Map(),
+}))
+
+vi.mock("../../../../lib/prismadb", () => ({
+  default: {
+    verificationToken: {
+      findFirst: vi.fn(),
+      delete: vi.fn(),
+    },
+  },
+}))
+
+vi.mock("@/utils/email", () => ({
+  normalizeEmail: vi.fn((email) => email),
+}))
+
+describe("POST /api/auth/otp", () => {
+  const logSpy = vi.spyOn(console, "log").mockImplementation(() => {})
+  // errorSpy removed as unused
+
+  beforeEach(() => {
+    vi.clearAllMocks()
+    process.env.AUTH_SECRET = "secret"
+    // Reset map
+    ;(otpFailures as unknown as Map<unknown, unknown>).clear()
+  })
+
+  afterEach(() => {
+    vi.restoreAllMocks()
+  })
+
+  it("should log the sensitive token when verification fails", async () => {
+    const req = {
+      json: vi.fn().mockResolvedValue({ email: "test@example.com", token: "123456" }),
+    } as unknown as Request
+
+    // Simulate verification token not found
+    const findFirstMock = prisma.verificationToken.findFirst as unknown as ReturnType<typeof vi.fn>
+    findFirstMock.mockResolvedValue(null)
+
+    await POST(req)
+
+    // Verify vulnerability: check if the token is logged
+    // The vulnerability is that it logs { identifier: key, token: fullToken }
+    // fullToken is token + . + hash
+    // We expect token to be redacted
+    expect(logSpy).toHaveBeenCalledWith(
+      "No valid verification token found for:",
+      expect.objectContaining({
+        identifier: "test@example.com",
+        token: "[REDACTED]",
+      }),
+    )
+  })
+})

--- a/src/app/api/auth/otp/route.ts
+++ b/src/app/api/auth/otp/route.ts
@@ -66,7 +66,7 @@ export async function POST(req: Request) {
     })
 
     if (!verificationToken) {
-      console.log("No valid verification token found for:", { identifier: key, token: fullToken })
+      console.log("No valid verification token found for:", { identifier: key, token: "[REDACTED]" })
       handleSignInFailure(key, fail, now)
       return NextResponse.json({ message: "Invalid or expired code." }, { status: 401 })
     } // Token is valid, delete it so it can't be reused


### PR DESCRIPTION
This PR addresses a security vulnerability where the full OTP verification token was being logged to the console when verification failed.

**Changes:**
- Modified `src/app/api/auth/otp/route.ts` to replace the `fullToken` with `"[REDACTED]"` in the log message.
- Added `src/app/api/auth/otp/route.test.ts` to verify that the token is redacted in the logs.

**Risk:**
- The previous implementation exposed sensitive tokens in logs, which could be exploited if logs were compromised.

**Validation:**
- Ran `npm test -- src/app/api/auth/otp/route.test.ts` to confirm the fix.
- Ran `npm run lint` to ensure code quality.

---
*PR created automatically by Jules for task [8211158341065153194](https://jules.google.com/task/8211158341065153194) started by @cakirmert*