### PR TITLE
🔒 [security] Secure uploadItemImage and prevent Stored XSS

### DIFF
--- a/src/server/routers/__tests__/uploadRouter.test.ts
+++ b/src/server/routers/__tests__/uploadRouter.test.ts
@@ -1,0 +1,113 @@
+import { describe, it, expect, vi, beforeEach } from "vitest"
+import { uploadRouter } from "../adminRouter"
+import { TRPCError } from "@trpc/server"
+import type { Context } from "@/server/context"
+import { put } from "@vercel/blob"
+
+// Mock @vercel/blob
+vi.mock("@vercel/blob", () => ({
+  put: vi.fn(),
+}))
+
+// Mock context helper
+const createMockContext = (role: string = "USER") => ({
+  prisma: {} as any,
+  session: {
+    user: {
+      id: "test-user-id",
+      role: role,
+    },
+  },
+} as unknown as Context)
+
+describe("uploadRouter.uploadItemImage", () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    process.env.BLOB_READ_WRITE_TOKEN = "test-token"
+  })
+
+  it("should throw FORBIDDEN if user is not an admin", async () => {
+    const ctx = createMockContext("USER")
+    const caller = uploadRouter.createCaller(ctx)
+
+    await expect(
+      caller.uploadItemImage({
+        fileName: "test.png",
+        fileContentBase64: "base64content",
+      })
+    ).rejects.toThrow()
+  })
+
+  it("should throw BAD_REQUEST if file extension is not allowed", async () => {
+    const ctx = createMockContext("ADMIN")
+    const caller = uploadRouter.createCaller(ctx)
+
+    try {
+      await caller.uploadItemImage({
+        fileName: "test.html",
+        fileContentBase64: "base64content",
+      })
+      expect.fail("Should have thrown")
+    } catch (error: any) {
+      expect(error.code).toBe("BAD_REQUEST")
+      expect(error.message).toContain("Only JPG, PNG, WEBP, and GIF are allowed")
+    }
+  })
+
+  it("should throw validation error if fileContentBase64 is too large", async () => {
+    const ctx = createMockContext("ADMIN")
+    const caller = uploadRouter.createCaller(ctx)
+
+    const largeContent = "a".repeat(11 * 1024 * 1024) // 11MB
+
+    await expect(
+      caller.uploadItemImage({
+        fileName: "test.png",
+        fileContentBase64: largeContent,
+      })
+    ).rejects.toThrow()
+  })
+
+  it("should upload successfully if user is admin and file is valid", async () => {
+    const ctx = createMockContext("ADMIN")
+    const caller = uploadRouter.createCaller(ctx)
+
+    vi.mocked(put).mockResolvedValue({ url: "https://blob.example.com/items/uuid.png", downloadUrl: "", pathname: "", size: 0, uploadedAt: new Date() })
+
+    const result = await caller.uploadItemImage({
+      fileName: "test.png",
+      fileContentBase64: Buffer.from("fake image content").toString("base64"),
+    })
+
+    expect(result).toEqual({ imageUrl: "https://blob.example.com/items/uuid.png" })
+    expect(put).toHaveBeenCalledWith(
+      expect.stringMatching(/^items\/.*\.png$/),
+      expect.any(Buffer),
+      expect.objectContaining({
+        contentType: "image/png",
+        access: "public",
+        token: "test-token",
+      })
+    )
+  })
+
+  it("should handle .jpg extension and use image/jpeg content type", async () => {
+    const ctx = createMockContext("ADMIN")
+    const caller = uploadRouter.createCaller(ctx)
+
+    vi.mocked(put).mockResolvedValue({ url: "https://blob.example.com/items/uuid.jpg", downloadUrl: "", pathname: "", size: 0, uploadedAt: new Date() })
+
+    await caller.uploadItemImage({
+      fileName: "test.jpg",
+      fileContentBase64: Buffer.from("fake image content").toString("base64"),
+    })
+
+    expect(put).toHaveBeenCalledWith(
+      expect.stringMatching(/^items\/.*\.jpg$/),
+      expect.any(Buffer),
+      expect.objectContaining({
+        contentType: "image/jpeg",
+      })
+    )
+  })
+})

--- a/src/server/routers/adminRouter.ts
+++ b/src/server/routers/adminRouter.ts
@@ -394,25 +394,47 @@ export const uploadRouter = router({
   uploadItemImage: protectedProcedure
     .input(
       z.object({
-        fileName: z.string(),
-        fileContentBase64: z.string(),
+        fileName: z.string().min(1).max(255),
+        fileContentBase64: z.string().max(10 * 1024 * 1024), // ~7.5MB binary
       }),
     )
-    .mutation(async ({ input }) => {
+    .mutation(async ({ ctx, input }) => {
+      ensureAdmin(ctx)
       try {
-        const fileExtension = path.extname(input.fileName)
+        const ALLOWED_EXTENSIONS = [".jpg", ".jpeg", ".png", ".webp", ".gif"]
+        const fileExtension = path.extname(input.fileName).toLowerCase()
+
+        if (!ALLOWED_EXTENSIONS.includes(fileExtension)) {
+          throw new TRPCError({
+            code: "BAD_REQUEST",
+            message: "Invalid file type. Only JPG, PNG, WEBP, and GIF are allowed.",
+          })
+        }
+
         const uniqueFileName = `items/${uuidv4()}${fileExtension}`
         const buffer = Buffer.from(input.fileContentBase64, "base64")
         const token = process.env.BLOB_READ_WRITE_TOKEN
         if (!token) throw new Error("Missing BLOB_READ_WRITE_TOKEN")
+
+        // Map extension to content type
+        const mimeType =
+          fileExtension === ".jpg" || fileExtension === ".jpeg"
+            ? "image/jpeg"
+            : `image/${fileExtension.slice(1)}`
+
         const { url } = await put(uniqueFileName, buffer, {
           access: "public",
           token,
+          contentType: mimeType,
         })
         return { imageUrl: url }
       } catch (error) {
+        if (error instanceof TRPCError) throw error
         console.error("Image upload failed:", error)
-        throw new Error("Image upload failed. Please try again.")
+        throw new TRPCError({
+          code: "INTERNAL_SERVER_ERROR",
+          message: "Image upload failed. Please try again.",
+        })
       }
     }),
 })


### PR DESCRIPTION
### 🎯 What: The vulnerability fixed
This PR addresses an **Unrestricted File Upload** and **Stored XSS** vulnerability in the `uploadItemImage` tRPC mutation.

### ⚠️ Risk: The potential impact if left unfixed
Previously, any authenticated user (even with no special roles) could upload any file type (including `.html` or `.js` files) to the public blob storage. This could be exploited to:
1.  **Stored XSS**: An attacker could upload a malicious HTML file and trick other users (or admins) into visiting its URL, potentially stealing sessions or performing actions on their behalf.
2.  **Unauthorized Storage Use**: Non-admin users could use up the storage quota.
3.  **DoS**: Large file uploads could potentially exhaust server memory during base64 processing.

### 🛡️ Solution: How the fix addresses the vulnerability
1.  **Authorization**: Added `ensureAdmin(ctx)` to restrict the procedure to users with the `ADMIN` role.
2.  **Extension Whitelisting**: Restricted allowed file extensions to `.jpg`, `.jpeg`, `.png`, `.webp`, and `.gif`.
3.  **Path Sanitization**: The final filename is generated using `uuidv4()` and the validated extension, ignoring the user-provided filename except for its extension.
4.  **Content-Type Enforcement**: Explicitly sets the `contentType` metadata when uploading to `@vercel/blob` based on the validated extension. This ensures the file is served with the correct headers, preventing browsers from executing it as code.
5.  **Size Limit**: Added a 10MB limit on the base64 string length (~7.5MB binary) via Zod validation.

**Note**: Due to environment limitations (missing `node_modules` and no internet access), tests could not be executed in the sandbox, but the logic has been thoroughly reviewed and a new test file `src/server/routers/__tests__/uploadRouter.test.ts` has been added for future verification.

---
*PR created automatically by Jules for task [483637667331251528](https://jules.google.com/task/483637667331251528) started by @cakirmert*