### PR TITLE
🧹 cleanup: remove debug console logs from AuthModalContext

### DIFF
--- a/src/contexts/AuthModalContext.tsx
+++ b/src/contexts/AuthModalContext.tsx
@@ -241,39 +241,8 @@ export const AuthModalProvider = ({ children }: { children: ReactNode }) => {
       try {
         const credential = await startAuthentication({ optionsJSON: options })
 
-        console.log("🔍 Raw credential from SimpleWebAuthn browser:", {
-          id: credential.id,
-          rawId: credential.rawId,
-          type: credential.type,
-          responseClientDataJSON: credential.response?.clientDataJSON?.substring(0, 50) + "...",
-          responseAuthenticatorData:
-            credential.response?.authenticatorData?.substring(0, 50) + "...",
-          responseSignature: credential.response?.signature?.substring(0, 50) + "...",
-          responseUserHandle: credential.response?.userHandle?.substring(0, 50) + "...",
-        })
-
         // SimpleWebAuthn browser already returns the correct format
         authenticationResponse = credential
-
-        console.log("🔐 Converted credential data:", {
-          id: authenticationResponse.id,
-          rawId: authenticationResponse.rawId,
-          responseClientDataJSON:
-            authenticationResponse.response.clientDataJSON?.substring(0, 50) + "...",
-          responseAuthenticatorData:
-            authenticationResponse.response.authenticatorData?.substring(0, 50) + "...",
-          responseSignature: authenticationResponse.response.signature?.substring(0, 50) + "...",
-          responseUserHandle: authenticationResponse.response.userHandle?.substring(0, 50) + "...",
-        })
-        console.log("🔐 Final credential data:", {
-          id: authenticationResponse.id,
-          rawId: authenticationResponse.rawId ? "present" : "undefined",
-          idLength: authenticationResponse.id?.length,
-          rawIdLength: authenticationResponse.rawId?.length,
-          clientDataJSONLength: authenticationResponse.response?.clientDataJSON?.length,
-          authenticatorDataLength: authenticationResponse.response?.authenticatorData?.length,
-          signatureLength: authenticationResponse.response?.signature?.length,
-        })
       } catch (browserError: unknown) {
         setAuthError(
           (browserError as Error)?.name === "NotAllowedError"


### PR DESCRIPTION
This change removes leftover `console.log` statements in `src/contexts/AuthModalContext.tsx` that were used for debugging the WebAuthn passkey authentication flow. 

🎯 **What:** Removed three blocks of `console.log` statements that printed raw and processed WebAuthn credential details.
💡 **Why:** These logs are unnecessary for production and cluttered the console with sensitive (though public) credential data, making the codebase less maintainable and readable.
✅ **Verification:** The changes were verified by checking that no `console.log` statements remain in the file and ensuring that the logic (specifically the credential assignment) remains intact. Formatting was also verified with Prettier.
✨ **Result:** A cleaner, more maintainable `AuthModalContext.tsx` file.

---
*PR created automatically by Jules for task [1272881535566075812](https://jules.google.com/task/1272881535566075812) started by @cakirmert*