### PR TITLE
🧹 Simplify normalizeImages logic in mapItem.ts

### DIFF
--- a/src/lib/__tests__/mapItem.test.ts
+++ b/src/lib/__tests__/mapItem.test.ts
@@ -1,0 +1,88 @@
+import { describe, it, expect } from "vitest"
+import { mapDbItemToClient, type MappableItem } from "../mapItem"
+
+describe("mapDbItemToClient", () => {
+  const baseItem: MappableItem = {
+    id: "1",
+    titleEn: "Item 1",
+    descriptionEn: "Description 1",
+  }
+
+  it("should handle images as a non-empty array", () => {
+    const item: MappableItem = {
+      ...baseItem,
+      images: ["url1", "url2"],
+    }
+    const result = mapDbItemToClient(item, "en")
+    expect(result.images).toEqual(["url1", "url2"])
+  })
+
+  it("should filter falsy values and convert to string in images array", () => {
+    const item: MappableItem = {
+      ...baseItem,
+      images: ["url1", "", null as any, undefined as any, "url2"],
+    }
+    const result = mapDbItemToClient(item, "en")
+    expect(result.images).toEqual(["url1", "url2"])
+  })
+
+  it("should handle imagesJson when images is empty", () => {
+    const item: MappableItem = {
+      ...baseItem,
+      images: [],
+      imagesJson: '["url3", "url4"]',
+    }
+    const result = mapDbItemToClient(item, "en")
+    expect(result.images).toEqual(["url3", "url4"])
+  })
+
+  it("should prefer images array over imagesJson", () => {
+    const item: MappableItem = {
+      ...baseItem,
+      images: ["url1"],
+      imagesJson: '["url2"]',
+    }
+    const result = mapDbItemToClient(item, "en")
+    expect(result.images).toEqual(["url1"])
+  })
+
+  it("should handle invalid imagesJson", () => {
+    const item: MappableItem = {
+      ...baseItem,
+      images: [],
+      imagesJson: 'invalid json',
+    }
+    const result = mapDbItemToClient(item, "en")
+    expect(result.images).toBeUndefined()
+  })
+
+  it("should handle imagesJson not being an array", () => {
+    const item: MappableItem = {
+      ...baseItem,
+      images: [],
+      imagesJson: '{"url": "url1"}',
+    }
+    const result = mapDbItemToClient(item, "en")
+    expect(result.images).toBeUndefined()
+  })
+
+  it("should handle both images and imagesJson being empty or null", () => {
+    const item: MappableItem = {
+      ...baseItem,
+      images: null,
+      imagesJson: "",
+    }
+    const result = mapDbItemToClient(item, "en")
+    expect(result.images).toBeUndefined()
+  })
+
+  it("should filter falsy values and convert to string in parsed imagesJson", () => {
+    const item: MappableItem = {
+      ...baseItem,
+      images: [],
+      imagesJson: '["url1", "", null, "url2"]',
+    }
+    const result = mapDbItemToClient(item, "en")
+    expect(result.images).toEqual(["url1", "url2"])
+  })
+})

--- a/src/lib/mapItem.ts
+++ b/src/lib/mapItem.ts
@@ -17,20 +17,22 @@ export type MappableItem = {
 }
 
 function normalizeImages(item: MappableItem): string[] | undefined {
+  let source: unknown[] | undefined
+
   if (Array.isArray(item.images) && item.images.length > 0) {
-    return item.images.filter(Boolean).map((value) => String(value))
-  }
-  if (typeof item.imagesJson === "string" && item.imagesJson.trim().length > 0) {
+    source = item.images
+  } else if (typeof item.imagesJson === "string" && item.imagesJson.trim().length > 0) {
     try {
       const parsed = JSON.parse(item.imagesJson)
       if (Array.isArray(parsed)) {
-        return parsed.filter(Boolean).map((value) => String(value))
+        source = parsed
       }
     } catch {
-      return undefined
+      // Ignore parse errors
     }
   }
-  return undefined
+
+  return source?.filter(Boolean).map(String)
 }
 
 function normalizeRules(source: unknown): string | string[] | undefined {


### PR DESCRIPTION
This PR simplifies the `normalizeImages` function in `src/lib/mapItem.ts` to improve maintainability and readability. 

### 🎯 What:
- Refactored `normalizeImages` to first determine the source of images (either from the `images` array or by parsing `imagesJson`) and then perform a single `filter(Boolean).map(String)` operation.
- Added a new test file `src/lib/__tests__/mapItem.test.ts` to verify the image mapping logic.

### 💡 Why:
- The previous implementation had duplicated logic for filtering and mapping in both the direct array check and the JSON parsing block.
- Simplifying the flow reduces cognitive load and follows a more idiomatic pattern.

### ✅ Verification:
- Created 8 new test cases covering various scenarios (valid arrays, falsy values, valid/invalid JSON, priority handling).
- Verified the tests pass using `bun test` (fallback for missing `node_modules` in sandbox).
- Ran Prettier to ensure consistent formatting.

### ✨ Result:
- Cleaner, more maintainable code with zero change in external behavior.
- Better test coverage for the item mapping logic.

---
*PR created automatically by Jules for task [13004171169401908154](https://jules.google.com/task/13004171169401908154) started by @cakirmert*