### PR TITLE
⚡ Optimize chat notification creation (N+1 query)

### DIFF
--- a/src/server/routers/chatRouter.ts
+++ b/src/server/routers/chatRouter.ts
@@ -171,22 +171,23 @@ async function createMessageNotifications(
 
   const senderName = sender.name || "Someone"
 
-  for (const id of recips) {
-    const n = await ctx.prisma.notification.create({
-      data: {
-        userId: id,
-        bookingId: thread.booking.id,
-        type: "BOOKING_RESPONSE",
-        message: JSON.stringify({
-          key: "notifications.newChatMessage",
-          vars: {
-            item: thread.booking.item.titleEn,
-            sender: senderName,
-            message: body.length > 100 ? body.substring(0, 100) + "..." : body,
-          },
-        }),
-      },
-    })
+  const notifications = await ctx.prisma.notification.createManyAndReturn({
+    data: recips.map((id) => ({
+      userId: id,
+      bookingId: thread.booking.id,
+      type: "BOOKING_RESPONSE",
+      message: JSON.stringify({
+        key: "notifications.newChatMessage",
+        vars: {
+          item: thread.booking.item.titleEn,
+          sender: senderName,
+          message: body.length > 100 ? body.substring(0, 100) + "..." : body,
+        },
+      }),
+    })),
+  })
+
+  for (const n of notifications) {
     notificationEmitter.emit("new", n)
   }
 }


### PR DESCRIPTION
💡 **What:** Replaced iterative `ctx.prisma.notification.create` calls with a single `ctx.prisma.notification.createManyAndReturn` call in the `chatRouter`'s message notification helper.

🎯 **Why:** Resolves an N+1 query issue where notifications for multiple recipients were created sequentially, causing unnecessary database roundtrips. Using `createManyAndReturn` allows us to batch the inserts while still obtaining the notification objects needed for real-time emission.

📊 **Measured Improvement:** Database roundtrips for notifications reduced from N to 1. In a typical chat scenario with 2 recipients (user and assigned staff), this reduces the notification-related database load by 50%. Manual verification with a mock script confirmed the logic correctly handles multiple recipients and emits all necessary events.

---
*PR created automatically by Jules for task [4024174368819649059](https://jules.google.com/task/4024174368819649059) started by @cakirmert*