### PR TITLE
🧹 remove dead booking duration comments

### DIFF
--- a/src/components/BookingFormView.tsx
+++ b/src/components/BookingFormView.tsx
@@ -565,11 +565,6 @@ function BookingFormView(props: BookingFormViewProps) {
           return false
         }
       }
-      // Zod refine now handles max duration at form level
-      // if (differenceInHours(endDT, startDT) > 48) {
-      //   setFormError(t("errorMaxBookingDuration", { hours: 48 }));
-      //   return false;
-      // }
     } catch (e: unknown) {
       const msg = e instanceof Error ? e.message : String(e)
       setFormError(msg || t("errors.invalidDateTime"))


### PR DESCRIPTION
🎯 **What:** Removed commented-out logic for maximum booking duration in `src/components/BookingFormView.tsx`.
💡 **Why:** The logic was explicitly marked as being handled by Zod refinements at the form level, making this code dead and redundant. Removing it improves maintainability and readability.
✅ **Verification:** Verified that the removal was safe through code review and manual inspection of the surrounding logic.
✨ **Result:** A cleaner and more maintainable `BookingFormView.tsx`.

---
*PR created automatically by Jules for task [2069851172658245155](https://jules.google.com/task/2069851172658245155) started by @cakirmert*