### PR TITLE
Fix unreachable self-healing logic for unnormalized credential IDs

### DIFF
--- a/src/server/routers/webauthnRouter.ts
+++ b/src/server/routers/webauthnRouter.ts
@@ -239,12 +239,13 @@ export const webauthnRouter = router({
       const passkey = userPasskeys.find((p) => {
         const normalizedStoredId = normalizeCredentialId(p.credentialID)
         if (!normalizedStoredId) return false
-        // Check both normalized and direct ID
-        if (normalizedStoredId === normalizedIncomingCredentialId) return true
 
-        // Fix stored ID if it matches but wasn't normalized
-        if (p.credentialID === incomingCredentialCandidate) {
-          p.credentialID = normalizedStoredId
+        // Check if the normalized versions match
+        if (normalizedStoredId === normalizedIncomingCredentialId) {
+          // Fix stored ID if it wasn't already normalized
+          if (p.credentialID !== normalizedStoredId) {
+            p.credentialID = normalizedStoredId
+          }
           return true
         }
         return false


### PR DESCRIPTION
The `login` mutation in `webauthnRouter.ts` contained a logic error where the self-healing mechanism for unnormalized `credentialID`s was unreachable. Specifically, the code would return `true` as soon as a normalized match was found, skipping the code intended to update the unnormalized stored ID.

I modified the `passkey.find` predicate to combine the match check and the normalization fix. Now, when a match is identified via normalization, the code immediately checks if the stored `credentialID` needs normalization and updates it in memory. This ensures the corrected ID is included when the user record is updated later in the procedure.

Verification was performed using a standalone script that replicated the logic and confirmed that unnormalized IDs are correctly identified, matched, and updated. Existing utility tests were also run to ensure no regressions.

---
*PR created automatically by Jules for task [451172857259808742](https://jules.google.com/task/451172857259808742) started by @cakirmert*