### PR TITLE
🔒 Implement authentication for cache-status endpoint

### DIFF
--- a/src/app/api/cache-status/route.ts
+++ b/src/app/api/cache-status/route.ts
@@ -8,6 +8,15 @@ import { imageCache } from "@/lib/imageCache"
  */
 export async function GET(request: NextRequest) {
   try {
+    // Basic authentication check
+    const authHeader = request.headers.get("authorization")
+    const expectedToken =
+      process.env.CACHE_WARM_TOKEN || process.env.CRON_SECRET || process.env.AUTH_SECRET
+
+    if (expectedToken && authHeader !== `Bearer ${expectedToken}`) {
+      return NextResponse.json({ error: "Unauthorized" }, { status: 401 })
+    }
+
     const url = new URL(request.url)
     const checkUrls = url.searchParams.getAll("url")
 

--- a/src/lib/cacheWarmer.ts
+++ b/src/lib/cacheWarmer.ts
@@ -51,12 +51,17 @@ export async function warmImageCache() {
     const uncachedImages: string[] = []
     const cachedImages: string[] = []
 
+    // Prepare auth header for cache status check
+    const authToken =
+      process.env.CACHE_WARM_TOKEN || process.env.CRON_SECRET || process.env.AUTH_SECRET
+    const headers: HeadersInit = authToken ? { Authorization: `Bearer ${authToken}` } : {}
+
     try {
       // Use the new cache status API which is much faster
       const checkUrl = new URL("/api/cache-status", baseUrl)
       allImageUrls.forEach((url) => checkUrl.searchParams.append("url", url))
 
-      const cacheCheckResponse = await fetch(checkUrl.toString())
+      const cacheCheckResponse = await fetch(checkUrl.toString(), { headers })
       if (cacheCheckResponse.ok) {
         const cacheData = await cacheCheckResponse.json()
 
@@ -115,7 +120,7 @@ export async function warmImageCache() {
 
     // Final cache stats
     try {
-      await fetch(`${baseUrl}/api/cache-status`)
+      await fetch(`${baseUrl}/api/cache-status`, { headers })
     } catch {
       // Ignore stats errors
     }


### PR DESCRIPTION
The `/api/cache-status` endpoint was publicly accessible, disclosing internal cache statistics and a list of cached URLs. This could potentially leak information about the system's usage and stored assets.

This PR implements a standard Bearer token authentication check for the endpoint, similar to other internal administrative routes in the application. It also updates the `warmImageCache` utility to ensure it can still communicate with the secured endpoint.

---
*PR created automatically by Jules for task [16775372749662675971](https://jules.google.com/task/16775372749662675971) started by @cakirmert*