### PR TITLE
Normalize matched stored passkey ID during login

### DIFF
--- a/src/server/routers/webauthnRouter.ts
+++ b/src/server/routers/webauthnRouter.ts
@@ -239,12 +239,16 @@ export const webauthnRouter = router({
       const passkey = userPasskeys.find((p) => {
         const normalizedStoredId = normalizeCredentialId(p.credentialID)
         if (!normalizedStoredId) return false
-        // Check both normalized and direct ID
-        if (normalizedStoredId === normalizedIncomingCredentialId) return true
 
-        // Fix stored ID if it matches but wasn't normalized
-        if (p.credentialID === incomingCredentialCandidate) {
-          p.credentialID = normalizedStoredId
+        // Check both normalized and direct ID
+        if (
+          normalizedStoredId === normalizedIncomingCredentialId ||
+          p.credentialID === incomingCredentialCandidate
+        ) {
+          // Fix stored ID if it matches but wasn't normalized
+          if (p.credentialID !== normalizedStoredId) {
+            p.credentialID = normalizedStoredId
+          }
           return true
         }
         return false


### PR DESCRIPTION
This PR implements "self-healing" logic for WebAuthn passkey credential IDs during the login process.

### Changes
- Modified `src/server/routers/webauthnRouter.ts` to ensure `p.credentialID` is normalized whenever a match is found.
- Consolidated the matching and normalization logic in the `.find()` callback.

### Verification
- Created a reproduction script `repro_webauthn.test.ts` using `bun test` to verify that unnormalized stored IDs are correctly updated to their normalized form when matched.
- Manually reviewed the `login` mutation to ensure the updated `userPasskeys` array is persisted to the database via `ctx.prisma.user.update`.

---
*PR created automatically by Jules for task [4831291448749016202](https://jules.google.com/task/4831291448749016202) started by @cakirmert*