### PR TITLE
🧹 code health: remove unused Modifiers import in BookingFormView

### DIFF
--- a/src/components/BookingFormView.tsx
+++ b/src/components/BookingFormView.tsx
@@ -40,7 +40,7 @@ import { useI18n } from "@/locales/i18n"
 import { toast } from "@/components/ui/use-toast"
 import { BookingRulesDialog } from "@/components/BookingRulesDialog"
 import type { Session } from "next-auth"
-import { type DateRange, type Modifiers } from "react-day-picker" // Use Modifiers instead of DayModifiers
+import { type DateRange } from "react-day-picker"
 import { trpc } from "@/utils/trpc"
 import InteractiveTimeRangePicker from "@/components/InteractiveTimeRangePicker"
 import { Spinner } from "@/components/ui/spinner"
@@ -456,11 +456,11 @@ function BookingFormView(props: BookingFormViewProps) {
   const minSelectableDateOverall = startOfDay(new Date())
 
   // Dynamic date disabling logic for the calendar
-  const disableDate = (day: Date, modifiers: Modifiers, selectedFromDate?: Date): boolean => {
+  const disableDate = (day: Date, selectedFromDate?: Date): boolean => {
     if (isBefore(day, minSelectableDateOverall)) {
       return true // Disable past dates
     }
-    if (selectedFromDate && !modifiers.selected) {
+    if (selectedFromDate) {
       // If a 'from' date is selected and we are evaluating other dates
       if (
         Number.isFinite(maxSelectableRangeDays) &&
@@ -1030,7 +1030,7 @@ function BookingFormView(props: BookingFormViewProps) {
                             }}
                             locale={currentLocale}
                             // Pass the field.value.from to the disableDate function context
-                            disabled={(day: Date) => disableDate(day, {}, field.value?.from)}
+                            disabled={(day: Date) => disableDate(day, field.value?.from)}
                             autoFocus
                           />
                         </div>


### PR DESCRIPTION
🎯 **What:** Removed an unused import (`Modifiers` from `react-day-picker`) in `src/components/BookingFormView.tsx` and removed the dead `modifiers` parameter from the `disableDate` function where it was being used as a type annotation.

💡 **Why:** The `disableDate` function was only called in one place where the `modifiers` parameter was hardcoded to an empty object `{}`. The function's logic safely handled this by evaluating `!modifiers.selected` to true. By removing this parameter entirely, we simplified the code, removed dead logic, and legitimately resolved the unneeded import.

✅ **Verification:** Verified that `npx tsc --noEmit` and the existing tests (`npm test`) passed successfully without errors.

✨ **Result:** Improved code cleanliness by removing an unneeded type import and dead parameters in the component.

---
*PR created automatically by Jules for task [7033337444617155037](https://jules.google.com/task/7033337444617155037) started by @cakirmert*