### PR TITLE
🧹 [Code Health] Remove unnecessary import in utils.ts

### DIFF
--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -1,6 +1,6 @@
-import { clsx, type ClassValue } from "clsx"
+import { clsx } from "clsx"
 import { twMerge } from "tailwind-merge"
 
-export function cn(...inputs: ClassValue[]) {
+export function cn(...inputs: Parameters<typeof clsx>) {
   return twMerge(clsx(inputs))
 }


### PR DESCRIPTION
🎯 **What:** Removed the explicit `ClassValue` type import from `clsx` in `src/lib/utils.ts`.
💡 **Why:** This improves the code health by clearing up a potentially unnecessary type import. Using `Parameters<typeof clsx>` infers the type exactly as needed from the library, preventing any TypeScript errors while keeping the file tidy.
✅ **Verification:** Ran `npx tsc --noEmit` and successfully executed the test suite (`npm test`). Verified that `cn()` operates exactly as before and handles identical parameters safely.
✨ **Result:** A cleaner `utils.ts` without explicit type imports from external styling utility libraries, improving overall maintainability.

---
*PR created automatically by Jules for task [10428007813441475496](https://jules.google.com/task/10428007813441475496) started by @cakirmert*