### PR TITLE
🧹 Remove unused React import from CancelledByStaffTab

### DIFF
--- a/src/components/admin/CancelledByStaffTab.tsx
+++ b/src/components/admin/CancelledByStaffTab.tsx
@@ -1,6 +1,5 @@
 "use client"
 
-import React from "react"
 import { trpc } from "@/utils/trpc"
 import { useI18n } from "@/locales/i18n"
 import { Card, CardHeader, CardTitle, CardContent, CardDescription } from "@/components/ui/card"


### PR DESCRIPTION
🎯 **What:** Removed the unused `import React from "react"` statement from `src/components/admin/CancelledByStaffTab.tsx`.
💡 **Why:** With the new JSX transform in modern React (and Next.js App Router where "use client" is utilized), importing React is no longer necessary unless explicit React APIs like `useState` or `useEffect` are called directly from the default export. This specific import was dead code. Removing it improves code maintainability, reduces noise, and resolves any potential linter warnings regarding unused variables.
✅ **Verification:** Verified that the code builds correctly, tests pass without issue, and the unused import is successfully eliminated.
✨ **Result:** Cleaner code file and improved code health.

---
*PR created automatically by Jules for task [12654320569856018589](https://jules.google.com/task/12654320569856018589) started by @cakirmert*