### PR TITLE
🧹 refactor(ui): clean up unused React imports in alert.tsx

### DIFF
--- a/src/components/ui/alert.tsx
+++ b/src/components/ui/alert.tsx
@@ -1,4 +1,4 @@
-import * as React from "react"
+import { forwardRef, type HTMLAttributes } from "react"
 import { cva, type VariantProps } from "class-variance-authority"
 
 import { cn } from "@/lib/utils"
@@ -19,15 +19,15 @@ const alertVariants = cva(
   },
 )
 
-const Alert = React.forwardRef<
+const Alert = forwardRef<
   HTMLDivElement,
-  React.HTMLAttributes<HTMLDivElement> & VariantProps<typeof alertVariants>
+  HTMLAttributes<HTMLDivElement> & VariantProps<typeof alertVariants>
 >(({ className, variant, ...props }, ref) => (
   <div ref={ref} role="alert" className={cn(alertVariants({ variant }), className)} {...props} />
 ))
 Alert.displayName = "Alert"
 
-const AlertTitle = React.forwardRef<HTMLParagraphElement, React.HTMLAttributes<HTMLHeadingElement>>(
+const AlertTitle = forwardRef<HTMLParagraphElement, HTMLAttributes<HTMLHeadingElement>>(
   ({ className, ...props }, ref) => (
     <h5
       ref={ref}
@@ -38,9 +38,9 @@ const AlertTitle = React.forwardRef<HTMLParagraphElement, React.HTMLAttributes<H
 )
 AlertTitle.displayName = "AlertTitle"
 
-const AlertDescription = React.forwardRef<
+const AlertDescription = forwardRef<
   HTMLParagraphElement,
-  React.HTMLAttributes<HTMLParagraphElement>
+  HTMLAttributes<HTMLParagraphElement>
 >(({ className, ...props }, ref) => (
   <div ref={ref} className={cn("text-sm [&_p]:leading-relaxed", className)} {...props} />
 ))


### PR DESCRIPTION
🎯 **What:** The code health issue addressed was the presence of an unnecessarily broad namespace import (`import * as React from "react"`) in `src/components/ui/alert.tsx`, which modern React configurations flag as potentially unused or suboptimal since JSX no longer requires React to be in scope.

💡 **Why:** How this improves maintainability: By importing only the specific hooks and types needed (`forwardRef`, `HTMLAttributes`), the code is cleaner, more concise, avoids triggering linter warnings for unused imports, and adheres better to modern React best practices.

✅ **Verification:** How you confirmed the change is safe: 
- Ran `npx tsc --noEmit` to confirm no TypeScript errors were introduced and that all `forwardRef` and `HTMLAttributes` types matched correctly.
- Ran the full test suite via `npm test` and ensured no tests related to UI components failed (the only failure was an existing legacy failure in an unrelated auth route).
- Received approval via automated Code Review.

✨ **Result:** The improvement achieved is a cleaner, more strictly-typed component file without unnecessary global namespace imports.

---
*PR created automatically by Jules for task [8745018650183239783](https://jules.google.com/task/8745018650183239783) started by @cakirmert*