### PR TITLE
🧹 Remove leftover console.logs from AuthModalContext

### DIFF
--- a/src/contexts/AuthModalContext.tsx
+++ b/src/contexts/AuthModalContext.tsx
@@ -241,39 +241,8 @@ export const AuthModalProvider = ({ children }: { children: ReactNode }) => {
       try {
         const credential = await startAuthentication({ optionsJSON: options })
 
-        console.log("🔍 Raw credential from SimpleWebAuthn browser:", {
-          id: credential.id,
-          rawId: credential.rawId,
-          type: credential.type,
-          responseClientDataJSON: credential.response?.clientDataJSON?.substring(0, 50) + "...",
-          responseAuthenticatorData:
-            credential.response?.authenticatorData?.substring(0, 50) + "...",
-          responseSignature: credential.response?.signature?.substring(0, 50) + "...",
-          responseUserHandle: credential.response?.userHandle?.substring(0, 50) + "...",
-        })
-
         // SimpleWebAuthn browser already returns the correct format
         authenticationResponse = credential
-
-        console.log("🔐 Converted credential data:", {
-          id: authenticationResponse.id,
-          rawId: authenticationResponse.rawId,
-          responseClientDataJSON:
-            authenticationResponse.response.clientDataJSON?.substring(0, 50) + "...",
-          responseAuthenticatorData:
-            authenticationResponse.response.authenticatorData?.substring(0, 50) + "...",
-          responseSignature: authenticationResponse.response.signature?.substring(0, 50) + "...",
-          responseUserHandle: authenticationResponse.response.userHandle?.substring(0, 50) + "...",
-        })
-        console.log("🔐 Final credential data:", {
-          id: authenticationResponse.id,
-          rawId: authenticationResponse.rawId ? "present" : "undefined",
-          idLength: authenticationResponse.id?.length,
-          rawIdLength: authenticationResponse.rawId?.length,
-          clientDataJSONLength: authenticationResponse.response?.clientDataJSON?.length,
-          authenticatorDataLength: authenticationResponse.response?.authenticatorData?.length,
-          signatureLength: authenticationResponse.response?.signature?.length,
-        })
       } catch (browserError: unknown) {
         setAuthError(
           (browserError as Error)?.name === "NotAllowedError"


### PR DESCRIPTION
🎯 **What:** Removed leftover debug `console.log` statements in `src/contexts/AuthModalContext.tsx` that were outputting passkey credential data.

💡 **Why:** `console.log` statements, especially those logging authentication credential structure details, are intended for debugging during development and should not be present in production code to keep the console clean and maintain good code hygiene.

✅ **Verification:** Verified the removal visually and structurally. The change is isolated to UI logging and does not affect the actual WebAuthn logic.

✨ **Result:** A cleaner production console output without unnecessary debug noise.

---
*PR created automatically by Jules for task [14893210234030719138](https://jules.google.com/task/14893210234030719138) started by @cakirmert*