### PR TITLE
🧹 refactor: remove unused `VariantProps` import in `ui/label`

### DIFF
--- a/src/components/ui/label.tsx
+++ b/src/components/ui/label.tsx
@@ -2,7 +2,7 @@
 
 import * as React from "react"
 import * as LabelPrimitive from "@radix-ui/react-label"
-import { cva, type VariantProps } from "class-variance-authority"
+import { cva } from "class-variance-authority"
 
 import { cn } from "@/lib/utils"
 
@@ -12,7 +12,7 @@ const labelVariants = cva(
 
 const Label = React.forwardRef<
   React.ElementRef<typeof LabelPrimitive.Root>,
-  React.ComponentPropsWithoutRef<typeof LabelPrimitive.Root> & VariantProps<typeof labelVariants>
+  React.ComponentPropsWithoutRef<typeof LabelPrimitive.Root>
 >(({ className, ...props }, ref) => (
   <LabelPrimitive.Root ref={ref} className={cn(labelVariants(), className)} {...props} />
 ))


### PR DESCRIPTION
🎯 **What:** Removed unused `type VariantProps` from imports and component prop typings in `src/components/ui/label.tsx`.
💡 **Why:** The `labelVariants` setup via `class-variance-authority` contains only base styles and no variant definitions. Consequently, `VariantProps<typeof labelVariants>` is functionally an empty object type (`{}`) and serves no purpose. Removing it cleans up an unused type import, resolving a code health issue.
✅ **Verification:** Verified that TypeScript compilation continues to pass (`npx tsc --noEmit`) and all tests still pass, confirming this cleanup is entirely safe and has no negative side effects.
✨ **Result:** A cleaner component file with improved maintainability and no unused imports.

---
*PR created automatically by Jules for task [11299083114866415813](https://jules.google.com/task/11299083114866415813) started by @cakirmert*