### PR TITLE
🧪 test: add coverage for deleteOldBookings cron task

### DIFF
--- a/src/server/jobs/__tests__/cleanOldBookings.test.ts
+++ b/src/server/jobs/__tests__/cleanOldBookings.test.ts
@@ -1,0 +1,42 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest"
+import { deleteOldBookings } from "../cleanOldBookings"
+
+vi.mock("@/lib/prismadb", () => {
+  return {
+    __esModule: true,
+    default: {
+      booking: {
+        deleteMany: vi.fn().mockResolvedValue({ count: 5 }),
+      },
+    },
+  }
+})
+
+import prisma from "@/lib/prismadb"
+
+describe("deleteOldBookings", () => {
+  beforeEach(() => {
+    vi.useFakeTimers()
+    vi.clearAllMocks()
+  })
+
+  afterEach(() => {
+    vi.useRealTimers()
+  })
+
+  it("deletes bookings older than 180 days", async () => {
+    const mockNow = new Date("2024-01-01T12:00:00.000Z")
+    vi.setSystemTime(mockNow)
+
+    await deleteOldBookings()
+
+    const expectedThreshold = new Date(mockNow.getTime() - 180 * 24 * 60 * 60 * 1000)
+
+    expect(prisma.booking.deleteMany).toHaveBeenCalledTimes(1)
+    expect(prisma.booking.deleteMany).toHaveBeenCalledWith({
+      where: {
+        endDate: { lt: expectedThreshold },
+      },
+    })
+  })
+})


### PR DESCRIPTION
🎯 **What:** The testing gap addressed
The `deleteOldBookings` cron task in `src/server/jobs/cleanOldBookings.ts` lacked test coverage, which left its threshold logic (180 days) unverified.

📊 **Coverage:** What scenarios are now tested
- The test mocks `@/lib/prismadb` to intercept the database call.
- Fake timers (`vi.useFakeTimers()`) are used to ensure the date calculation is deterministic.
- Assertions verify that `prisma.booking.deleteMany` is called with an `endDate` strictly less than 180 days from the current system time.

✨ **Result:** The improvement in test coverage
The critical background task is now covered by an automated test that validates the query logic without running side effects against a real database.

---
*PR created automatically by Jules for task [7959269977651641154](https://jules.google.com/task/7959269977651641154) started by @cakirmert*