### PR TITLE
fix: add missing German translation for bookingForm.notesGuidance

### DIFF
--- a/src/locales/de.json
+++ b/src/locales/de.json
@@ -332,6 +332,7 @@
     "endTimeLabel": "Endzeit",
     "quantityLabel": "Menge",
     "notesLabel": "Notizen (Optional)",
+    "notesGuidance": "Für Anfragen oder Fragen nutze den Chat nach der Buchung für eine schnellere Kommunikation mit dem Verleih-Team.",
     "continueToBookingButton": "Weiter zur Buchung",
     "completeFormToSeeSummary": "Fülle das Formular aus, um die Buchungsübersicht zu sehen.",
     "invalidPeriod": "Ungültige Datums-/Zeitauswahl.",


### PR DESCRIPTION
Adds the missing German translation for `notesGuidance` within the `bookingForm` section of `src/locales/de.json`. The translation is "Für Anfragen oder Fragen nutze den Chat nach der Buchung für eine schnellere Kommunikation mit dem Verleih-Team.", matching the informal tone used in other German translations.

---
*PR created automatically by Jules for task [4009577297963922513](https://jules.google.com/task/4009577297963922513) started by @cakirmert*